### PR TITLE
Hide unused providers (Google, Mistral, Groq, Perplexity) from model dropdown

### DIFF
--- a/lib/models/fetch-models.ts
+++ b/lib/models/fetch-models.ts
@@ -5,7 +5,10 @@ import { LLM_LIST_MAP } from "./llm/llm-list"
 
 export const fetchHostedModels = async (profile: Tables<"profiles">) => {
   try {
-    const providers = ["google", "anthropic", "mistral", "groq", "perplexity"]
+    // Providers deshabilitados (06/2026): google, mistral, groq, perplexity.
+    // Para resucitarlos, agregarlos a este array y descomentar las entradas
+    // correspondientes en lib/models/llm/llm-list.ts.
+    const providers = ["anthropic"]
 
     if (profile.use_azure_openai) {
       providers.push("azure")

--- a/lib/models/llm/llm-list.ts
+++ b/lib/models/llm/llm-list.ts
@@ -1,26 +1,23 @@
 import { LLM } from "@/types"
 import { ANTHROPIC_LLM_LIST } from "./anthropic-llm-list"
-import { GOOGLE_LLM_LIST } from "./google-llm-list"
-import { MISTRAL_LLM_LIST } from "./mistral-llm-list"
-import { GROQ_LLM_LIST } from "./groq-llm-list"
 import { OPENAI_LLM_LIST } from "./openai-llm-list"
-import { PERPLEXITY_LLM_LIST } from "./perplexity-llm-list"
 
-export const LLM_LIST: LLM[] = [
-  ...OPENAI_LLM_LIST,
-  ...GOOGLE_LLM_LIST,
-  ...MISTRAL_LLM_LIST,
-  ...GROQ_LLM_LIST,
-  ...PERPLEXITY_LLM_LIST,
-  ...ANTHROPIC_LLM_LIST
-]
+// Providers deshabilitados (06/2026). Los archivos y rutas siguen ahí
+// por si en el futuro queremos resucitarlos — solo no se incluyen en
+// la agregación que puebla el dropdown del UI.
+// import { GOOGLE_LLM_LIST } from "./google-llm-list"
+// import { MISTRAL_LLM_LIST } from "./mistral-llm-list"
+// import { GROQ_LLM_LIST } from "./groq-llm-list"
+// import { PERPLEXITY_LLM_LIST } from "./perplexity-llm-list"
+
+export const LLM_LIST: LLM[] = [...OPENAI_LLM_LIST, ...ANTHROPIC_LLM_LIST]
 
 export const LLM_LIST_MAP: Record<string, LLM[]> = {
   openai: OPENAI_LLM_LIST,
   azure: OPENAI_LLM_LIST,
-  google: GOOGLE_LLM_LIST,
-  mistral: MISTRAL_LLM_LIST,
-  groq: GROQ_LLM_LIST,
-  perplexity: PERPLEXITY_LLM_LIST,
   anthropic: ANTHROPIC_LLM_LIST
+  // google: GOOGLE_LLM_LIST,
+  // mistral: MISTRAL_LLM_LIST,
+  // groq: GROQ_LLM_LIST,
+  // perplexity: PERPLEXITY_LLM_LIST
 }


### PR DESCRIPTION
## Summary

Reduce el dropdown de modelos a solo Anthropic + OpenAI. Después del PR #105 quedaban 5 modelos curados de esos dos providers, pero el dropdown seguía mostrando los modelos viejos de Google, Mistral, Groq y Perplexity.

Este PR los oculta del UI sin destruir nada — es totalmente reversible.

## Scope

Cambios en **2 archivos** únicamente:

- `lib/models/llm/llm-list.ts` — `LLM_LIST` y `LLM_LIST_MAP` ahora solo contienen OpenAI + Anthropic. Los imports de los otros providers quedan comentados con un marcador `06/2026`.
- `lib/models/fetch-models.ts` — array `providers` en `fetchHostedModels` reducido a `["anthropic"]` (+ azure/openai según `profile.use_azure_openai`).

## Lo que NO se toca (por si los queremos resucitar)

- Archivos `llm-list.ts` de los providers ocultos
- Rutas `app/api/chat/{google,mistral,groq,perplexity}/route.ts`
- Tipos en `types/llms.ts`, `valid-keys.ts`, `key-type.ts`
- Inputs en el setup wizard y profile settings
- Overrides por env var en `server-chat-helpers.ts`

## Cómo resucitar un provider más adelante

1. Descomentar el import + entrada en `lib/models/llm/llm-list.ts`
2. Agregar el string del provider al array en `lib/models/fetch-models.ts`

30 segundos de trabajo.

## Verification

- ✅ `npx tsc --noEmit` pasa con 0 errores

## Test plan

- [ ] Mergear → Vercel redeploya `main` → `ai.pixelspace.com` se actualiza
- [ ] Abrir el dropdown del selector y confirmar que solo se ven:
  - **Anthropic**: Claude Sonnet 4.6, Claude Haiku 4.5
  - **OpenAI**: GPT-5.5, GPT-5.4 mini, GPT-5.4 nano
- [ ] Confirmar que ningún provider de Google/Mistral/Groq/Perplexity aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)